### PR TITLE
Patch lodash for vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "google-auth-library": "^0.10.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.12",
     "xmlbuilder": "^4.2.0",
     "request": "*"
   },


### PR DESCRIPTION
The lodash module has High security vulnerabilities until 4.17.12 per npm audit

See https://npmjs.com/advisories/782 and https://npmjs.com/advisories/1065 

![image](https://user-images.githubusercontent.com/844828/72398682-a5d1c980-36f8-11ea-81b2-ac96e5c66724.png)
